### PR TITLE
Add timers to integration tests and generate test reports.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,6 +23,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
 Arrow = "2.3"
@@ -42,6 +43,7 @@ PlyIO = "1.1.2"
 SciMLBase = "1.60"
 TOML = "1"
 Tables = "1"
+TimerOutputs = "0.5"
 julia = "1.8"
 
 [extras]
@@ -50,6 +52,7 @@ CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestReports = "dcd651b4-b50a-5b6b-8f22-87e9f253a252"
 
 [targets]
-test = ["Aqua", "CSV", "Downloads", "SafeTestsets", "Test"]
+test = ["Aqua", "CSV", "Downloads", "SafeTestsets", "Test", "TestReports"]

--- a/src/Ribasim.jl
+++ b/src/Ribasim.jl
@@ -21,8 +21,12 @@ using ModelingToolkitStandardLibrary.Blocks
 using OrdinaryDiffEq
 using SciMLBase
 using Serialization: serialize, deserialize
+using TimerOutputs
 
 export interpolator, Register, ForwardFill
+
+const to = TimerOutput()
+TimerOutputs.complement!()
 
 include("validation.jl")
 include("utils.jl")

--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -211,8 +211,15 @@ function BMI.initialize(T::Type{Register}, config::AbstractDict)
     endtime = DateTime(config["endtime"])
     run_modflow = get(config, "run_modflow", false)::Bool
 
-    (; ids, edge, node, state, static, profile, forcing) =
-        load_data(config, starttime, endtime)
+    @timeit_debug to "Load and validate data" (;
+        ids,
+        edge,
+        node,
+        state,
+        static,
+        profile,
+        forcing,
+    ) = load_data(config, starttime, endtime)
     nodetypes = Dictionary(node.id, node.node)
 
     function allocate!(integrator)
@@ -236,7 +243,7 @@ function BMI.initialize(T::Type{Register}, config::AbstractDict)
 
     if haskey(config, "cache") && isfile(config["cache"])
         @info "Using cached problem" path = config["cache"]
-        prob = deserialize(config["cache"])
+        @timeit_debug to "Deserialize problem" prob = deserialize(config["cache"])
     else
         sysdict = create_nodes(node, state, profile, static)
         connect_eqs = connect_systems(edge, sysdict)
@@ -250,9 +257,11 @@ function BMI.initialize(T::Type{Register}, config::AbstractDict)
         @named sys = ODESystem(eqs, t, [], []; systems)
 
         # TODO use input_idxs rather than parse_paramsyms
-        sim, input_idxs = structural_simplify(sys, (; inputs, outputs = []))
+        @timeit_debug to "Structural simplify" sim, input_idxs =
+            structural_simplify(sys, (; inputs, outputs = []))
 
-        prob = ODAEProblem(sim, [], tspan; sparse = true)
+        @timeit_debug to "Setup ODAEProblem" prob =
+            ODAEProblem(sim, [], tspan; sparse = true)
         if haskey(config, "cache")
             @info "Caching initialized problem" path = config["cache"]
             open(config["cache"], "w") do io
@@ -338,7 +347,8 @@ function BMI.initialize(T::Type{Register}, config::AbstractDict)
         p[infiltration_index] .= rme.basin_infiltration.values ./ 86400.0
     end
 
-    wbal_entries, prev_state = prepare_waterbalance(syms)
+    @timeit_debug to "Prepare waterbalance" wbal_entries, prev_state =
+        prepare_waterbalance(syms)
     waterbalance = DataFrame(;
         time = DateTime[],
         variable = String[],
@@ -383,7 +393,7 @@ function BMI.initialize(T::Type{Register}, config::AbstractDict)
         save_positions = (false, false),
     )
 
-    callback = if run_modflow
+    @timeit_debug to "Setup callbackset" callback = if run_modflow
         modflow_cb = PeriodicCallback(exchange_modflow!, Δt_modflow; initial_affect = true)
         CallbackSet(forcing_cb, allocation_cb, output_cb, modflow_cb)
     else
@@ -391,7 +401,7 @@ function BMI.initialize(T::Type{Register}, config::AbstractDict)
     end
 
     saveat = get(config, "saveat", [])
-    integrator = init(
+    @timeit_debug to "Setup integrator" integrator = init(
         prob,
         TRBDF2();
         progress = true,

--- a/test/config.jl
+++ b/test/config.jl
@@ -1,7 +1,7 @@
 using Ribasim
 
 @testset "config" begin
-    config = Ribasim.parsefile("testrun.toml")
+    config = Ribasim.parsefile(joinpath(@__DIR__, "testrun.toml"))
     @test typeof(config) == Dict{String, Any}
     @test config["update_timestep"] == 86400.0
     @test length(config["ids"]) > 0

--- a/test/equations.jl
+++ b/test/equations.jl
@@ -7,6 +7,8 @@ import BasicModelInterface as BMI
 using SciMLBase
 using TimerOutputs
 
+include("../utils/testdata.jl")  # to include Teamcity specific utils
+
 datadir = normpath(@__DIR__, "..", "data")
 
 TimerOutputs.enable_debug_timings(Ribasim)  # causes recompilation (!)

--- a/test/equations.jl
+++ b/test/equations.jl
@@ -5,10 +5,13 @@ using Ribasim: name
 using Arrow
 import BasicModelInterface as BMI
 using SciMLBase
+using TimerOutputs
 
 datadir = normpath(@__DIR__, "..", "data")
 
-@testset "qh_relation" begin
+TimerOutputs.enable_debug_timings(Ribasim)  # causes recompilation (!)
+
+@timeit_debug to "qh_relation" @testset "qh_relation" begin
     # LSW without forcing
     config = Dict{String, Any}()
     id_lsw = 1
@@ -64,7 +67,12 @@ datadir = normpath(@__DIR__, "..", "data")
     @test diff(S) ≈ -diff(S2)
 end
 
-@testset "forcing_eqs" begin
+show(Ribasim.to)
+println()
+is_running_under_teamcity() && teamcity_message("qh_relation", TimerOutputs.todict(to))
+reset_timer!(Ribasim.to)
+
+@timeit_debug to "forcing_eqs" @testset "forcing_eqs" begin
     config = Dict{String, Any}()
     # 151358 with downstream LSW
     id_lsw = 14908
@@ -130,6 +138,11 @@ end
     @test all(urban_runoff[1:10] .≈ 0.0027895224861111114f0)
     @test all(urban_runoff[11:20] .≈ 0.003847473439814815f0)
 end
+
+show(Ribasim.to)
+println()
+is_running_under_teamcity() && teamcity_message("forcing_eqs", TimerOutputs.todict(to))
+TimerOutputs.disable_debug_timings(Ribasim)  # causes recompilation (!)
 
 # @testset "bifurcation" begin
 

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,4 +1,7 @@
 using Ribasim
+using TestReports
+
+recordproperty("name", "Input/Output")  # TODO To check in TeamCity
 
 @testset "parsename" begin
     test_sym = Symbol(:sys_151358₊agric₊alloc)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Ribasim, Test, SafeTestsets, Aqua
+using Ribasim, Test, SafeTestsets, TimerOutputs, Aqua
 
 include("../utils/testdata.jl")
 
@@ -15,15 +15,19 @@ testdata("static.arrow", "lhm/static.arrow")
 
 @testset "Ribasim" begin
     @safetestset "Input/Output" begin
+        using TestReports
+        recordproperty("name", "Input/Output")  # TODO To check in TeamCity
         include("io.jl")
     end
     @safetestset "Configuration" begin
         include("config.jl")
     end
+
     # @safetestset "Water allocation" begin include("alloc.jl") end
     @safetestset "Equations" begin
         include("equations.jl")
     end
+
     @safetestset "Basin" begin
         include("basin.jl")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ testdata("static.arrow", "lhm/static.arrow")
 
     # @safetestset "Water allocation" begin include("alloc.jl") end
     @safetestset "Equations" begin
+        include("../utils/testdata.jl")  # to include Teamcity specific utils
         include("equations.jl")
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,8 +15,6 @@ testdata("static.arrow", "lhm/static.arrow")
 
 @testset "Ribasim" begin
     @safetestset "Input/Output" begin
-        using TestReports
-        recordproperty("name", "Input/Output")  # TODO To check in TeamCity
         include("io.jl")
     end
     @safetestset "Configuration" begin
@@ -25,7 +23,6 @@ testdata("static.arrow", "lhm/static.arrow")
 
     # @safetestset "Water allocation" begin include("alloc.jl") end
     @safetestset "Equations" begin
-        include("../utils/testdata.jl")  # to include Teamcity specific utils
         include("equations.jl")
     end
 

--- a/utils/testdata.jl
+++ b/utils/testdata.jl
@@ -1,6 +1,7 @@
 using Downloads
 # ensure test data is present
 datadir = normpath(@__DIR__, "..", "data")
+const teamcity_presence_env_var = "TEAMCITY_VERSION"
 
 "Download a test data file if it does not already exist"
 function testdata(source_filename, target_filename = source_filename)
@@ -12,4 +13,18 @@ function testdata(source_filename, target_filename = source_filename)
     url = string(base_url, source_filename)
     isfile(target_path) || Downloads.download(url, target_path)
     return target_path
+end
+
+is_running_under_teamcity() = haskey(ENV, teamcity_presence_env_var)
+
+function teamcity_message(name, value)
+    println("##teamcity['$name' '$value']")
+end
+
+function teamcity_message(name, d::Dict)
+    println(
+        "##teamcity[$name " *
+        string(collect(("'$(key)'='$value' " for (key, value) in pairs(d)))...) *
+        "]",
+    )
 end


### PR DESCRIPTION
For Teamcity, the test report generation requires `julia --project -e "using Ribasim; using TestReports; TestReports.test(\"Ribasim\")"`. After that you should have a `testlog.xml` which Teamcity can parse.

Both the place of the `@timeit_debug`, as now timing the two sytems in equations.jl are up for debate and should be changed once we have a proper integration setup running. For now this should provide all the building blocks to have something running.