### PR TITLE
Explain how to add developer dependency on Ribasim

### DIFF
--- a/docs/developer.qmd
+++ b/docs/developer.qmd
@@ -108,6 +108,14 @@ you can activate this project by entering the Pkg mode of the REPL with `]` and 
 pkg> activate run
 ```
 
+The first time you do this, you will also have to tell it where it can find the Ribasim module itself.
+This can be done with `dev .` to tell it to develop the module in the current directory.
+
+```julia
+(run) pkg> dev .
+```
+
+
 Press backspace to go back to the Julia REPL.
 There you can execute the run file with:
 ```julia

--- a/run/README.md
+++ b/run/README.md
@@ -2,3 +2,12 @@ This folder is a Julia project meant for running Ribasim simulations and post-pr
 
 Assuming your working directory is the root of the repository, you can activate this project
 by entering the Pkg mode of the REPL with `]` and running `activate run`.
+The first time you do this, you will also have to tell it where it can find the Ribasim module itself.
+This can be done with `dev .` to tell it to develop the module in the current directory.
+
+```julia
+(Ribasim) pkg> activate run
+  Activating project at `path/to/Ribasim/run`
+
+(run) pkg> dev .
+```


### PR DESCRIPTION
Now that there is no run manifest anymore this has to be done by the user