### PR TITLE
Use initial state, make transient forcing work

### DIFF
--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -64,14 +64,14 @@ function BMI.initialize(T::Type{Register}, config::Config)
 
     @timeit_debug to "Setup ODEProblem" begin
         # use state
-        state = load_data(db, config, "Basin / state")
+        state = load_dataframe(db, config, "Basin / state")
         n = length(get_ids(db, "Basin"))
-        u0 = if state === nothing
+        if isnothing(state)
             # default to nearly empty basins, perhaps make required input
-            fill(1.0, n)
+            u0 = fill(1.0, n)
         else
             # get state in the right order
-            sort(DataFrame(state), :node_id)[!, :storage]::Vector{Float64}
+            u0 = sort(state, :node_id)[!, :storage]::Vector{Float64}
         end
         @assert length(u0) == n "Basin / state length differs from number of Basins"
         prob = ODEProblem(water_balance!, u0, tspan, parameters)

--- a/src/construction.jl
+++ b/src/construction.jl
@@ -20,6 +20,21 @@ function load_data(db::DB, config::Config, tablename::String)::Union{Table, Quer
     return nothing
 end
 
+
+function load_dataframe(db::DB, config::Config, tablename::String)::Union{DataFrame, Nothing}
+    query = load_data(db, config, tablename)
+    if isnothing(query)
+        return nothing
+    end
+
+    df = DataFrame(query)
+    if hasproperty(df, :time)
+        df.time = DateTime.(df.time)
+    end
+    return df
+end
+
+
 function load_required_data(
     db::DB,
     config::Config,

--- a/src/create.jl
+++ b/src/create.jl
@@ -61,7 +61,7 @@ function create_level_control(db::DB, config::Config)
     data === nothing && return LevelControl()
     tbl = columntable(data)
     # TODO add LevelControl conductance to LHM / ribasim-python datasets
-    conductance = fill(10.0 / (3600.0 * 24), length(tbl.node_id))
+    conductance = fill(100.0 / (3600.0 * 24), length(tbl.node_id))
     return LevelControl(tbl.node_id, tbl.target_level, conductance)
 end
 
@@ -101,8 +101,8 @@ function create_basin(db::DB, config::Config)
     timespan = [datetime2unix(config.starttime), datetime2unix(config.endtime)]
 
     # both static and forcing are optional, but we need fallback defaults
-    static = load_data(db, config, "Basin")
-    forcing = load_data(db, config, "Basin / forcing")
+    static = load_dataframe(db, config, "Basin")
+    forcing = load_dataframe(db, config, "Basin / forcing")
     if forcing === nothing
         # empty forcing so nothing is found
         forcing = DataFrame(;
@@ -113,8 +113,6 @@ function create_basin(db::DB, config::Config)
             drainage = Float64[],
             infiltration = Float64[],
         )
-    else
-        forcing = DataFrame(forcing)
     end
     if static === nothing
         # empty static so nothing is found
@@ -125,8 +123,6 @@ function create_basin(db::DB, config::Config)
             drainage = Float64[],
             infiltration = Float64[],
         )
-    else
-        static = DataFrame(static)
     end
 
     precipitation = Interpolation[]


### PR DESCRIPTION
In SQLite, there's no specific datetime type.

This would trip up with a dynamic forcing, as datetime2unix doesn't work for strings.
It seems convenient in general to have a `load_dataframe` function.