### PR TITLE
use simulation starttime as t = 0, not 1970

### DIFF
--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -126,6 +126,10 @@ function BMI.update_until(reg::Register, time)
 end
 
 BMI.get_current_time(reg::Register) = reg.integrator.t
+BMI.get_start_time(reg::Register) = 0.0
+BMI.get_end_time(reg::Register) = seconds_since(reg.config.endtime, reg.config.starttime)
+BMI.get_time_units(reg::Register) = "s"
+BMI.get_time_step(reg::Register) = get_proposed_dt(reg.integrator)
 
 run(config_file::AbstractString) = run(parsefile(config_file))
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -29,12 +29,29 @@ function split_tablename(tablename)
     return Symbol(nodetype), Symbol(kind)
 end
 
-function write_basin_output(reg::Register, config::Config)
-    (; sol, p) = reg.integrator
+"""
+    seconds_since(t::DateTime, t0::DateTime)::Float64
+
+Convert a DateTime to a float that is the number of seconds since the start of the
+simulation. This is used to convert between the solver's inner float time, and the calendar.
+"""
+seconds_since(t::DateTime, t0::DateTime)::Float64 = 0.001 * Dates.value(t - t0)
+
+"""
+    time_since(t::Real, t0::DateTime)::DateTime
+
+Convert a Real that represents the seconds passed since the simulation start to the nearest
+DateTime. This is used to convert between the solver's inner float time, and the calendar.
+"""
+time_since(t::Real, t0::DateTime)::DateTime = t0 + Millisecond(round(1000 * t))
+
+function write_basin_output(reg::Register)
+    (; config, integrator) = reg
+    (; sol, p) = integrator
 
     basin_id = collect(keys(p.connectivity.u_index))
     nbasin = length(basin_id)
-    tsteps = unix2datetime.(timesteps(reg))
+    tsteps = time_since.(timesteps(reg), config.starttime)
     ntsteps = length(tsteps)
 
     time = convert.(Arrow.DATETIME, repeat(tsteps; inner = nbasin))
@@ -52,15 +69,16 @@ function write_basin_output(reg::Register, config::Config)
     Arrow.write(path, basin; compress = :lz4)
 end
 
-function write_flow_output(reg::Register, config::Config)
-    (; t, saveval) = reg.saved_flow
-    (; connectivity) = reg.integrator.p
+function write_flow_output(reg::Register)
+    (; config, saved_flow, integrator) = reg
+    (; t, saveval) = saved_flow
+    (; connectivity) = integrator.p
 
     I, J, _ = findnz(connectivity.flow)
     nflow = length(I)
     ntsteps = length(t)
 
-    time = convert.(Arrow.DATETIME, repeat(unix2datetime.(t); inner = nflow))
+    time = convert.(Arrow.DATETIME, repeat(time_since.(t, config.starttime); inner = nflow))
     from_node_id = repeat(I; outer = ntsteps)
     to_node_id = repeat(J; outer = ntsteps)
     flow = collect(Iterators.flatten(saveval))

--- a/src/lib.jl
+++ b/src/lib.jl
@@ -3,6 +3,7 @@
 """
     Register(
         sys::MTK.AbstractODESystem,
+        config::Config,
         saved_flow::SavedValues(Float64, Vector{Float64}),
         integrator::SciMLBase.AbstractODEIntegrator
     )
@@ -12,21 +13,24 @@ model construction.
 """
 struct Register{T}
     integrator::T
+    config::Config
     saved_flow::SavedValues{Float64, Vector{Float64}}
     waterbalance::DataFrame
     function Register(
         integrator::T,
+        config,
         saved_flow,
         waterbalance,
     ) where {T <: SciMLBase.AbstractODEIntegrator}
-        new{T}(integrator, saved_flow, waterbalance)
+        new{T}(integrator, config, saved_flow, waterbalance)
     end
 end
 
 timesteps(reg::Register) = reg.integrator.sol.t
 
 function Base.show(io::IO, reg::Register)
-    t = unix2datetime(reg.integrator.t)
-    nsaved = length(reg.integrator.sol.t)
+    (; config, integrator) = reg
+    t = time_since(integrator.t, config.starttime)
+    nsaved = length(timesteps(reg))
     println(io, "Register(ts: $nsaved, t: $t)")
 end

--- a/test/bmi.jl
+++ b/test/bmi.jl
@@ -1,0 +1,22 @@
+using Ribasim
+import BasicModelInterface as BMI
+
+toml_path = normpath(@__DIR__, "../data/basic/basic.toml")
+model = BMI.initialize(Ribasim.Register, toml_path)
+
+@testset "time" begin
+    @test BMI.get_time_units(model) == "s"
+    @test BMI.get_time_step(model) == 86400.0
+    @test BMI.get_start_time(model) === 0.0
+    @test BMI.get_current_time(model) === 0.0
+    @test BMI.get_end_time(model) ≈ 3.16224e7
+    BMI.update(model)
+    @test BMI.get_current_time(model) == 86400.0
+    @test_throws ErrorException BMI.update_until(model, 1.0)
+    @test BMI.get_current_time(model) == 86400.0
+    BMI.update_until(model, 86400.0)
+    @test BMI.get_current_time(model) == 86400.0
+    # suggest a 100 second step, but due to fixed dt it takes a full timestep
+    BMI.update_until(model, 86500.0)
+    @test BMI.get_current_time(model) == 2 * 86400.0
+end

--- a/test/io.jl
+++ b/test/io.jl
@@ -32,3 +32,13 @@ recordproperty("name", "Input/Output")  # TODO To check in TeamCity
         Ribasim.Config(; starttime = now(), endtime = now(), geopackage = "/path/to/file")
     @test Ribasim.input_path(config, "/path/to/file") == abspath("/path/to/file")
 end
+
+@testset "time" begin
+    t0 = DateTime(2020)
+    @test Ribasim.time_since(0.0, t0) === t0
+    @test Ribasim.time_since(1.0, t0) === t0 + Second(1)
+    @test Ribasim.time_since(pi, t0) === DateTime("2020-01-01T00:00:03.142")
+    @test Ribasim.seconds_since(t0, t0) === 0.0
+    @test Ribasim.seconds_since(t0 + Second(1), t0) === 1.0
+    @test Ribasim.seconds_since(DateTime("2020-01-01T00:00:03.142"), t0) ≈ 3.142
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,5 +37,9 @@ testdata(
         include("basin.jl")
     end
 
+    @safetestset "Basic Model Interface" begin
+        include("bmi.jl")
+    end
+
     Aqua.test_all(Ribasim; ambiguities = false)
 end


### PR DESCRIPTION
Internally we need to represent time as a floating point number. That means we need a method to convert from DateTime to this float and vice-versa. So far we used Unix time, seconds since 1970. This was convenient at first since there was a global datum.

There were several downsides to using unix time however. First of all, the floats were hard to read when debugging: `datetime2unix(now()) == 1.677761097515e9`. The precision is enough for Float64 (`eps(ans) = 2.384185791015625e-7`), but if we want to move to Float32 it could give issues, especially when moving further away from 1970.

So instead this maps the starttime to 0.0. This will have more precision, and to avoid hard to debug accuracy errors we error out if `eps(t_end)` is higher than 1 hour. We need the `config.starttime` to convert, but usually have Config available anyway. I put the Config in the Register struct as well to be able to map times after running a simulation as well.

Note: I considered two other options. Option 1 was to always run from 0 to 1, but not having a fixed time unit is inconvenient, and not convenient for the BMI for instance. I also considered using days since starttime, but then you need to do `du .*= 86400` to get `du` right. which doesn't feel great.

BMI also states most models start time at 0.0: https://bmi.readthedocs.io/en/stable/#get-start-time
I suggested a similar change for Wflow.jl: https://github.com/Deltares/Wflow.jl/pull/246