### PR TITLE
Simplify cmd script

### DIFF
--- a/compile/create_binaries/create_app.jl
+++ b/compile/create_binaries/create_app.jl
@@ -29,13 +29,7 @@ add_metadata(project_dir, license_file, output_dir, git_repo)
 if Sys.iswindows()
     cmd = raw"""
     @echo off
-    setlocal
-
-    set bindir=%~dp0bin
-    set path=%bindir%;%path%
-    "%bindir%\ribasim.exe" %*
-
-    endlocal
+    "%~dp0bin\ribasim.exe" %*
     """
     open(normpath(output_dir, "ribasim.cmd"); write = true) do io
         print(io, cmd)


### PR DESCRIPTION
Turns out we don't need to modify the PATH after all.
As long as all DLLs live in the same folder as the executable, at least